### PR TITLE
add contributor points

### DIFF
--- a/content/authors/kirandeol/_index.md
+++ b/content/authors/kirandeol/_index.md
@@ -39,6 +39,7 @@ email: "kdeol@ualberta.ca"
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
   - 2023 Contributors
+  - University of California Mentors
 ---
 
 Kiran is a computing science undergrada at the university of Alberta.

--- a/content/authors/luarss/_index.md
+++ b/content/authors/luarss/_index.md
@@ -42,6 +42,7 @@ email: ""
 # Organizational groups that you belong to (for People widget)
 #   Set this to `[]` or comment out if you are not using People widget.  
 user_groups:
+  - 2023 Contributors
   - University of California Mentors
 ---
 Jack is a Masters graduate from the National University of Singapore. Key interests are in open-source Electronic Design Automation (EDA) and applying AI for Very Large Scale Integration (VLSI) design optimisation. 

--- a/content/osre23/mentors.md
+++ b/content/osre23/mentors.md
@@ -1,5 +1,5 @@
 ---
-widget: people
+widget: peoplecm
 headless: true
 active: true
 weight: 80
@@ -16,6 +16,7 @@ design:
   columns: '2'
   show_social: false
   show_interests: false
+  show_latest_of_year: true
   background: {}
 advanced:
   css_style: ''

--- a/layouts/partials/blox-core/functions/get_sort_by_parameter.html
+++ b/layouts/partials/blox-core/functions/get_sort_by_parameter.html
@@ -1,0 +1,24 @@
+{{/* Uniform 'sort_by' parameter between built-in Hugo and Hugo Blox Builder ones */}}
+{{/* Input: 'sort_by' parameter (string) */}}
+{{/* Output: fixed 'sort_by' parameter (string) */}}
+
+{{/*
+    Fix the 'sort_by' parameter, by adding "Params." as prefix if it is not a built-in Hugo parameter.
+    Since Hugo Blox Builder parameters are all standardised to lowercase-underscore convention, we:
+    - remove any leading ".": ".Date" is the same as "Date"
+    - check the first letter:
+        - if it is capitalized, then we have a built-in Hugo parameter, and we do nothing
+        - otherwise, it is a custom Hugo Blox Builder parameter, and we add "Params." as prefix
+    This logic should also be backward compatible, since "Params.my_param" is not modified.
+*/}}
+
+{{ $param := strings.TrimLeft "." . }}
+{{/* Get first letter */}}
+{{ $first := substr $param 0 }}
+{{/* Check if it is lowercase */}}
+{{ if eq $first (lower $first) }}
+    {{/* Add 'Params.' prefix */}}
+    {{ $param = printf "Params.%s" $param }}
+{{ end }}
+
+{{ return $param }}

--- a/layouts/partials/latest_of_year.html
+++ b/layouts/partials/latest_of_year.html
@@ -1,0 +1,14 @@
+{{/* Need to understand this query and scope to the given year */}}
+
+{{ $query := where .Pages ".IsNode" false }}
+{{ $count := len $query }}
+{{ if $count }}
+    <ul class="network-icon" aria-hidden="true">
+        {{ range $query }}
+            <li>
+                <a href="{{ .RelPermalink }}">●</a>
+            </li>
+            {{/* $count := minus $count 1 */}}
+        {{ end }}
+    </ul>
+{{ end }}

--- a/layouts/partials/widgets/peoplecm.html
+++ b/layouts/partials/widgets/peoplecm.html
@@ -1,0 +1,79 @@
+{{/* Hugo Blox: People */}}
+{{/* Documentation: https://hugoblox.com/blocks/ */}}
+{{/* License: https://github.com/HugoBlox/hugo-blox-builder/blob/main/LICENSE.md */}}
+{{/* CM: Add links to Latest of given year */}}
+
+{{/* Initialise */}}
+{{ $page := .wcPage }}
+{{ $block := .page.Params }}
+{{ $show_social := $block.design.show_social | default false }}
+{{ $show_interests := $block.design.show_interests | default true }}
+{{ $show_organizations := $block.design.show_organizations | default false }}
+{{ $show_role := $block.design.show_role | default true }}
+{{ $show_latest_of_year := $block.design.show_latest_of_year | default false }}
+<div class="row justify-content-center people-widget">
+  {{ with $block.content.title }}
+    <div class="section-heading col-12 mb-3 text-center">
+      <h1 class="mb-0">{{ . | markdownify | emojify }}</h1>
+      {{ with $block.content.subtitle }}<p class="mt-1">{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
+
+  {{ with $block.content.text }}
+    <div class="col-md-12">
+      {{ . | emojify | $page.RenderString }}
+    </div>
+  {{ end }}
+
+  {{ range $block.content.user_groups }}
+    {{ $group := . }}
+    {{/*  warnf "%[1]v (%[1]T)" $group */}}
+    {{ $inContributors := hasSuffix $group "Contributors" }}
+    {{/* warnf "%[1]v (%[1]T)" $inContributors */}}
+    {{ $query := where (where site.Pages "Section" "authors") ".Params.user_groups" "intersect" (slice .) }}
+
+    {{/* Sort */}}
+    {{ $sort_by := $block.content.sort_by | default "Params.last_name" }}
+    {{ $sort_by = partial "blox-core/functions/get_sort_by_parameter" $sort_by }}
+    {{ $sort_ascending := $block.content.sort_ascending | default true }}
+    {{ $sort_order := cond $sort_ascending "asc" "desc" }}
+    {{ $query = sort $query $sort_by $sort_order }}
+
+    {{if $query | and (gt (len $block.content.user_groups) 1) }}
+      <div class="col-md-12">
+        <h2 class="mb-4">{{ . | markdownify }}</h2>
+      </div>
+    {{end}}
+
+    {{ range $query }}
+      {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
+      {{/* Get link to user's profile page. */}}
+      {{ $link := "" }}
+      {{ with site.GetPage (printf "/authors/%s" (path.Base .File.Dir)) }}
+        {{ $link = .RelPermalink }}
+      {{ end }}
+      <div class="col-12 col-sm-auto people-person">
+        {{ $src := "" }}
+        {{ if site.Params.features.avatar.gravatar }}
+          {{ $src = printf "https://s.gravatar.com/avatar/%s?s=150" (md5 .Params.email) }}
+        {{ else if $avatar }}
+          {{ $avatar_image := $avatar.Fill "270x270 Center" }}
+          {{ $src = $avatar_image.RelPermalink }}
+        {{ end }}
+        {{ if $src }}
+          {{ $avatar_shape := site.Params.features.avatar.shape | default "circle" }}
+          {{with $link}}<a href="{{.}}">{{end}}<img width="270" height="270" loading="lazy" class="avatar {{if eq $avatar_shape "square"}}avatar-square{{else}}avatar-circle{{end}}" src="{{ $src }}" alt="Avatar">{{if $link}}</a>{{end}}
+        {{ end }}
+
+        <div class="portrait-title">
+          <h2>{{with $link}}<a href="{{.}}">{{end}}{{ .Title }}{{if $link}}</a>{{end}}</h2>
+          {{ if and $show_organizations .Params.organizations }}{{ range .Params.organizations }}<h3>{{ .name }}</h3>{{ end }}{{ end }}
+          {{ if and $show_role .Params.role }}<h3>{{ .Params.role | markdownify | emojify }}</h3>{{ end }}
+          {{ if $show_social }}{{ partial "social_links" . }}{{ end }}
+          {{ if and $inContributors $show_latest_of_year }}{{ partial "latest_of_year" . }}{{ end }}
+          {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit .Params.interests ", " | markdownify | emojify }}</p>{{ end }}
+        </div>
+      </div>
+    {{ end }}
+  {{ end }}
+</div>


### PR DESCRIPTION
"Contributor points" are points that appear under each contributor for each post they (co-)authored. This provides a quick way to see who contributed how many student pages, for example. Each point is represented by a ● that links to the corresponding post. These points only appear under user groups that end with "Contributors", e.g. "2023 Contributors" or "2024 Contributors" (case-sensitive). 