### PR TITLE
add featured event

### DIFF
--- a/content/event/20241001/index.md
+++ b/content/event/20241001/index.md
@@ -31,7 +31,7 @@ featured: true
 
 image:
   caption: ''
-  focal_point: Right
+  focal_point: ""
 
 url_code: ''
 url_pdf: ''

--- a/content/home/featured.md
+++ b/content/home/featured.md
@@ -4,7 +4,7 @@ widget_id: Home
 headless: true
 weight: 15
 active: true
-title: Featured
+title: Featured Posts
 subtitle: 
 design:
   columns: "3"

--- a/content/home/featuredevent.md
+++ b/content/home/featuredevent.md
@@ -1,0 +1,33 @@
+---
+widget: featured
+widget_id: Home
+headless: true
+weight: 12
+active: true
+title: Featured Event
+subtitle: 
+design:
+  columns: "3"
+  css_style: null
+  css_class: null
+content:
+  # Page type to display. E.g. post, event, or publication.
+  page_type: event
+  # Choose how much pages you would like to display (0 = all pages)
+  count: 1
+  # Page order. Descending (desc) or ascending (asc) date.
+  order: desc
+  # Optionally filter posts by a taxonomy term.
+  filters:
+    tag: ''
+    category: ''
+    publication_type: ''
+design:
+  # Toggle between the various page layout types.
+  #   1 = List
+  #   2 = Compact
+  #   3 = Card
+  #   4 = Citation (publication only)
+  view: card
+---
+


### PR DESCRIPTION
Some blog entries can be "featured" under the intro part of the home page by setting `featured: true` in the blog entry. Events can also have that setting but are a different page type and I found myself unable to get them mixed with featured blog entries. I was only able to come up with a separate section for "Featured Events". This section is now between the intro section and the "Featured" section and lists at most one event. Hopefully this will make the current event more visible from the home page. Please review.